### PR TITLE
Fixed run time memory leaks in Geant4 

### DIFF
--- a/source/processes/hadronic/models/cascade/cascade/src/G4PreCompoundDeexcitation.cc
+++ b/source/processes/hadronic/models/cascade/cascade/src/G4PreCompoundDeexcitation.cc
@@ -107,7 +107,12 @@ void G4PreCompoundDeexcitation::deExcite(const G4Fragment& fragment,
     globalOutput.setVerboseLevel(verboseLevel);	// For debugging
     globalOutput.addOutgoingParticles(precompoundProducts);
     globalOutput.setVerboseLevel(0);
-
+    for ( size_t i = 0; i < precompoundProducts->size(); i++ ) {
+      if ( (*precompoundProducts)[ i ] ) {
+        delete (*precompoundProducts)[ i ];
+        (*precompoundProducts)[ i ] = 0;
+      }
+    }
     precompoundProducts->clear();
     delete precompoundProducts;
   }

--- a/source/processes/hadronic/models/de_excitation/photon_evaporation/include/G4NuclearLevelManager.hh
+++ b/source/processes/hadronic/models/de_excitation/photon_evaporation/include/G4NuclearLevelManager.hh
@@ -102,7 +102,7 @@ private:
   G4bool ReadDataItem(std::istream& dataFile, G4double& x);
   void ProcessDataLine();
 
-  void MakeLevels();
+  void MakeLevels(const G4String& filename);
   void ClearLevels();
 
   G4NuclearLevel* UseLevelOrMakeNew(G4NuclearLevel* level);
@@ -111,7 +111,7 @@ private:
 
   G4int _nucleusA;
   G4int _nucleusZ;
-  G4String _fileName;
+  //  G4String _fileName;
   G4bool _validity;
   G4PtrLevelVector* _levels;
 

--- a/source/processes/hadronic/models/de_excitation/photon_evaporation/src/G4NuclearLevelManager.cc
+++ b/source/processes/hadronic/models/de_excitation/photon_evaporation/src/G4NuclearLevelManager.cc
@@ -61,7 +61,7 @@
 
 G4NuclearLevelManager::G4NuclearLevelManager(G4int Z, G4int A, 
 					     const G4String& filename) :
-    _nucleusA(A), _nucleusZ(Z), _fileName(filename), _validity(false), 
+    _nucleusA(A), _nucleusZ(Z), _validity(false), 
     _levels(0), _levelEnergy(0), _gammaEnergy(0), _probability(0)
 { 
   if (A <= 0 || Z <= 0 || Z > A ) {
@@ -69,7 +69,7 @@ G4NuclearLevelManager::G4NuclearLevelManager(G4int Z, G4int A,
 			      "==== G4NuclearLevelManager ==== (Z,A) <0, or Z>A");
   }
   for(G4int i=0; i<30; ++i) { buffer[i] = 0; }
-  MakeLevels();
+  MakeLevels(filename);
 }
 
 G4NuclearLevelManager::~G4NuclearLevelManager()
@@ -87,8 +87,8 @@ void G4NuclearLevelManager::SetNucleus(G4int Z, G4int A, const G4String& filenam
     {
       _nucleusA = A;
       _nucleusZ = Z;
-      _fileName = filename;
-      MakeLevels();
+      //      _fileName = filename;
+      MakeLevels(filename);
     }
 }
 
@@ -263,12 +263,12 @@ void G4NuclearLevelManager::ClearLevels()
   _levels = 0;
 }
 
-void G4NuclearLevelManager::MakeLevels()
+void G4NuclearLevelManager::MakeLevels(const G4String& filename)
 {
   _validity = false;
   if (NumberOfLevels() > 0) ClearLevels();	// Discard existing data
 
-  std::ifstream inFile(_fileName, std::ios::in);
+  std::ifstream inFile(filename, std::ios::in);
   if (! inFile) 
     {
 #ifdef GAMMAFILEWARNING
@@ -381,7 +381,7 @@ G4NuclearLevelManager::G4NuclearLevelManager(const G4NuclearLevelManager &right)
   _totalCC = right._totalCC;
   _nucleusA = right._nucleusA;
   _nucleusZ = right._nucleusZ;
-  _fileName = right._fileName;
+  //_fileName = right._fileName;
   _validity = right._validity;
 
   for(G4int i=0; i<30; ++i) { buffer[i] = 0; }

--- a/source/processes/hadronic/models/parton_string/diffraction/include/G4FTFParticipants.hh
+++ b/source/processes/hadronic/models/parton_string/diffraction/include/G4FTFParticipants.hh
@@ -63,6 +63,7 @@ class G4FTFParticipants : public G4VParticipants {
     void SortInteractionsIncT();
     void ShiftInteractionTime();
     G4InteractionContent& GetInteraction();  
+    void Clean();
     std::vector< G4InteractionContent* > theInteractions;
 
   private:

--- a/source/processes/hadronic/models/parton_string/diffraction/src/G4FTFModel.cc
+++ b/source/processes/hadronic/models/parton_string/diffraction/src/G4FTFModel.cc
@@ -154,6 +154,8 @@ void G4FTFModel::Init( const G4Nucleus& aNucleus, const G4DynamicParticle& aProj
          << " " << aNucleus.GetZ_asInt() << G4endl;
   #endif
 
+  theParticipants.Clean();
+
   theParticipants.SetProjectileNucleus( 0 );
 
   G4LorentzVector tmp( 0.0, 0.0, 0.0, 0.0 );
@@ -348,7 +350,7 @@ G4ExcitedStringVector* G4FTFModel::GetStrings() {
          << "To continue - enter 1, to stop - ^C" << G4endl;
   G4int Uzhi; G4cin >> Uzhi;
   #endif
-
+  theParticipants.Clean();
   return theStrings;
 }
 

--- a/source/processes/hadronic/models/parton_string/diffraction/src/G4FTFParticipants.cc
+++ b/source/processes/hadronic/models/parton_string/diffraction/src/G4FTFParticipants.cc
@@ -347,3 +347,17 @@ void G4FTFParticipants::ShiftInteractionTime() {
   }
   return;
 }
+
+//============================================================================
+
+void G4FTFParticipants::Clean() {
+  for ( size_t i = 0; i < theInteractions.size(); i++ ) {
+    if ( theInteractions[ i ] ) {
+      delete theInteractions[ i ];
+      theInteractions[ i ] = 0;
+    }
+  }
+  theInteractions.clear();
+  currentInteraction = -1;
+}
+


### PR DESCRIPTION
Back port of fixes from 10.1p02 to 10.0p02:
- reduced memory in nuclear level data by removal of full file name
- run time leak in gamma-nuclear interactions
- run time leak in FTF model

Should not affect physics results - only remove memory grows. 
