### PR TITLE
Avoid using __has_feature(c_atomic) in C++ mode

### DIFF
--- a/source/externals/clhep/include/CLHEP/Utility/atomic_int.h
+++ b/source/externals/clhep/include/CLHEP/Utility/atomic_int.h
@@ -13,7 +13,7 @@
     #include <atomic>
     #define CLHEP_ATOMIC_INT_TYPE std::atomic<int>
   #elif __clang__
-    #if __has_feature(c_atomic)
+    #if __has_include(<atomic>)
       #include <atomic>
       #define CLHEP_ATOMIC_INT_TYPE std::atomic<int>
     #else

--- a/source/global/HEPRandom/include/Randomize.hh
+++ b/source/global/HEPRandom/include/Randomize.hh
@@ -33,7 +33,7 @@
 
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTHepRandom.cc
+++ b/source/global/HEPRandom/src/G4MTHepRandom.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTRandBit.cc
+++ b/source/global/HEPRandom/src/G4MTRandBit.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTRandExponential.cc
+++ b/source/global/HEPRandom/src/G4MTRandExponential.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTRandFlat.cc
+++ b/source/global/HEPRandom/src/G4MTRandFlat.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTRandGamma.cc
+++ b/source/global/HEPRandom/src/G4MTRandGamma.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTRandGauss.cc
+++ b/source/global/HEPRandom/src/G4MTRandGauss.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTRandGaussQ.cc
+++ b/source/global/HEPRandom/src/G4MTRandGaussQ.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif

--- a/source/global/HEPRandom/src/G4MTRandGeneral.cc
+++ b/source/global/HEPRandom/src/G4MTRandGeneral.cc
@@ -28,7 +28,7 @@
 //
 #if __clang__
   #if ((defined(G4MULTITHREADED) && !defined(G4USE_STD11)) || \
-      !__has_feature(cxx_thread_local)) || !__has_feature(c_atomic)
+      !__has_feature(cxx_thread_local))
     #define CLANG_NOSTDTLS
   #endif
 #endif


### PR DESCRIPTION
I have noticed that CMSSW is broken while compiling with Clang if we use new GEANT4 from DEVEL IBs. The problem due to usage of `__has_feature(c_atomic)` which checks for C11 `_Atomic` support, but C++11/C++14/C++1z refers to C99 thus it will never return true. Note, C++ standard does not define macro for testing for atomic, but we can use `__has_include(<atomic>)`.
