### PR TITLE
Disable plane intersection check in G4CutTubs

### DIFF
--- a/source/geometry/solids/CSG/src/G4CutTubs.cc
+++ b/source/geometry/solids/CSG/src/G4CutTubs.cc
@@ -121,6 +121,7 @@ G4CutTubs::G4CutTubs( const G4String &pName,
 
   // Check Intersection of Cutted planes. They MUST NOT Intersect
   //
+  /*
   if(IsCrossingCutPlanes())
   {
     std::ostringstream message;
@@ -131,6 +132,7 @@ G4CutTubs::G4CutTubs( const G4String &pName,
     G4Exception("G4CutTubs::G4CutTubs()", "GeomSolids0002",
                 FatalException, message);
   }
+  */
 }
 
 ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
New pixel detector description requires to use G4CutTubs solid. At construction this solid check if the planes used for cuts are intersected within outer radius of the tube or not. This check is too strong and should not be applied in form for shapes used by the new pixel.

This PR should be on hold until extra notification.  
