### PR TITLE
Fixed decay channels of K0 and antiK0

### DIFF
--- a/source/particles/management/src/G4VDecayChannel.cc
+++ b/source/particles/management/src/G4VDecayChannel.cc
@@ -128,6 +128,8 @@ G4VDecayChannel::G4VDecayChannel(const G4String  &aName,
   if (numberOfDaughters>1) daughters_name[1] = new G4String(theDaughterName2);
   if (numberOfDaughters>2) daughters_name[2] = new G4String(theDaughterName3);
   if (numberOfDaughters>3) daughters_name[3] = new G4String(theDaughterName4);
+  if      (rbranch <0.  ) rbranch = 0.0;
+  else if (rbranch >1.0 ) rbranch = 1.0;
 }
 
 G4VDecayChannel::G4VDecayChannel(const G4VDecayChannel &right)
@@ -420,6 +422,7 @@ void G4VDecayChannel::FillDaughters()
   // check sum of daghter mass
   G4double widthMass = std::sqrt(G4MT_parent->GetPDGWidth()*G4MT_parent->GetPDGWidth()+sumofdaughterwidthsq);
   if ( (G4MT_parent->GetParticleType() != "nucleus") &&
+       (numberOfDaughters !=1) &&
        (sumofdaughtermass > parentmass + rangeMass*widthMass) ){
    // !!! illegal mass  !!!
 #ifdef G4VERBOSE
@@ -566,6 +569,7 @@ const G4String& G4VDecayChannel::GetNoName() const
 #include "Randomize.hh"
 G4double G4VDecayChannel::DynamicalMass(G4double massPDG, G4double width, G4double maxDev ) const
 { 
+  if (width<=0.0) return massPDG;
   if (maxDev >rangeMass) maxDev = rangeMass;
   if (maxDev <=-1.*rangeMass) return massPDG;  // can not calculate
  
@@ -586,10 +590,11 @@ G4bool    G4VDecayChannel::IsOKWithParentMass(G4double parentMass)
   G4double sumOfDaughterMassMin=0.0;
   CheckAndFillParent();
   CheckAndFillDaughters();
+  if (numberOfDaughters==1) return true;
 
   for (G4int index=0; index < numberOfDaughters;  index++) { 
     sumOfDaughterMassMin += 
       G4MT_daughters_mass[index] -rangeMass*G4MT_daughters_width[index];
   }
-  return (parentMass > sumOfDaughterMassMin); 
+  return (parentMass >= sumOfDaughterMassMin); 
 }

--- a/source/processes/decay/src/G4Decay.cc
+++ b/source/processes/decay/src/G4Decay.cc
@@ -251,8 +251,35 @@ G4VParticleChange* G4Decay::DecayIt(const G4Track& aTrack, const G4Step& )
     decaychannel = decaytable->SelectADecayChannel(massParent);
     if ( decaychannel ==0) {
       // decay channel not found
-      G4Exception("G4Decay::DoIt", "DECAY003", FatalException,
-		  " can not determine decay channel ");
+           G4ExceptionDescription ed;
+      ed << "Can not determine decay channel for " 
+         << aParticleDef->GetParticleName() 
+	 << " trackID= " << aTrack.GetTrackID() 
+	 << " parentID= " << aTrack.GetParentID() 
+	 << G4endl 
+         << "  mass of dynamic particle: " 
+         << massParent/GeV << " (GEV)" << G4endl
+         << "  dacay table has " << decaytable->entries() 
+         << " entries" << G4endl;
+      G4double checkedmass=massParent;
+      if (massParent < 0.) {
+        checkedmass=aParticleDef->GetPDGMass();
+        ed << "Using PDG mass ("<<checkedmass/GeV 
+           << "(GeV)) in IsOKWithParentMass" << G4endl; 
+      }
+      for (G4int ic =0;ic <decaytable->entries();++ic) {
+        G4VDecayChannel * dc= decaytable->GetDecayChannel(ic);
+        ed << ic << ": BR " << dc->GetBR() << ", IsOK? " 
+           << dc->IsOKWithParentMass(checkedmass)
+           << ", --> "; 
+        G4int ndaughters=dc->GetNumberOfDaughters();
+        for (G4int id=0;id<ndaughters;++id) {
+          if (id>0) ed << " + ";   // seperator, except for first
+          ed << dc->GetDaughterName(id);
+        }
+        ed << G4endl;
+      }
+      G4Exception("G4Decay::DoIt", "DECAY003", FatalException,ed);
     } else {
       // execute DecayIt() 
 #ifdef G4VERBOSE


### PR DESCRIPTION
Back-ported fix to Geant4 10.2p02 for the treatment of K0 and antiK0, which is a part of Geant4 10.3. 
The problem was faced in attempt to start simulation production for XeXe run but may affect any workflow.

In G4VDecayChannel the fixes concerns so-called 1 body decay - transformation of K0 into KS or KL.

In G4Decay extended printout for G4Exception is added.