### PR TITLE
Backport G4 bug in indexes inside decay class

### DIFF
--- a/source/particles/management/src/G4PhaseSpaceDecayChannel.cc
+++ b/source/particles/management/src/G4PhaseSpaceDecayChannel.cc
@@ -547,7 +547,7 @@ G4DecayProducts *G4PhaseSpaceDecayChannel::ManyBodyDecayIt()
     //Calculate daughter momentum
     weight = 1.0;
     G4bool smOK=true;
-    for(index =0; index< numberOfDaughters-1 && smOK; index--) {
+    for(index =0; index< numberOfDaughters-1 && smOK; index++) {
       smOK = (sm[index]-daughtermass[index]- sm[index+1] >=0.); 
     }
     if (!smOK) continue;


### PR DESCRIPTION
The Geant4 problem of phase space decay was introduced for 10.2 release used in CMSSW_9_3_X. The problem was initially fixed for CMSSW_10_2_X for Geant4 10.4 #28.

Due to the request https://hypernews.cern.ch/HyperNews/CMS/get/prep-ops/5095/1/1/1/2/1/1/1/1/1/1/1.html  this PR is created.

This problem does not affect mainstream production but may show up in some special cases, so worse to fix it in the MC production release.