### PR TITLE
Fixed gcc7.0 warnings

### DIFF
--- a/source/processes/hadronic/management/include/G4HadLeadBias.hh
+++ b/source/processes/hadronic/management/include/G4HadLeadBias.hh
@@ -35,6 +35,7 @@
 class G4HadLeadBias : public G4VLeadingParticleBiasing
 {
   public:
+  G4HadLeadBias() {};
   virtual G4HadFinalState * Bias(G4HadFinalState * result);
   virtual ~G4HadLeadBias() {};
 };

--- a/source/processes/hadronic/management/include/G4VLeadingParticleBiasing.hh
+++ b/source/processes/hadronic/management/include/G4VLeadingParticleBiasing.hh
@@ -34,7 +34,10 @@ class G4HadFinalState;
 class G4VLeadingParticleBiasing 
 {
   public:
-  
+
+  G4VLeadingParticleBiasing() {};
+  ~G4VLeadingParticleBiasing() {};
+
   virtual G4HadFinalState * Bias(G4HadFinalState * result) = 0;
 };
 


### PR DESCRIPTION
This is a trivial fix of the annoying warnings at gcc7.0 happens in SimG4Core package. The class itself is not used in CMSSW. Should not affect anything.