### PR TITLE
make G4VLeadingParticleBiasing destructor virtual

### DIFF
--- a/source/processes/hadronic/management/include/G4VLeadingParticleBiasing.hh
+++ b/source/processes/hadronic/management/include/G4VLeadingParticleBiasing.hh
@@ -36,7 +36,7 @@ class G4VLeadingParticleBiasing
   public:
 
   G4VLeadingParticleBiasing() {};
-  ~G4VLeadingParticleBiasing() {};
+  virtual ~G4VLeadingParticleBiasing() {};
 
   virtual G4HadFinalState * Bias(G4HadFinalState * result) = 0;
 };


### PR DESCRIPTION
To avoid gcc700 warning in cmssw
```
In file included from Geant4/G4HadronicProcess.hh:58:0,
                 from Geant4/G4HadronInelasticProcess.hh:44,
                 fromGeant4/G4ProtonInelasticProcess.hh:38,
                 fromGeant4/G4PiKBuilder.hh:47,
                 from SimG4Core/PhysicsLists/interface/CMSHadronPhysicsFTFP_BERT_ATL.h:20,
                 from SimG4Core/PhysicsLists/src/CMSHadronPhysicsFTFP_BERT_ATL.cc:14:
Geant4/G4VLeadingParticleBiasing.hh:34:7: warning: 'class G4VLeadingParticleBiasing' has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
 class G4VLeadingParticleBiasing

```