### PR TITLE
Fixed gcc7.0 warning

### DIFF
--- a/source/processes/hadronic/management/include/G4VLeadingParticleBiasing.hh
+++ b/source/processes/hadronic/management/include/G4VLeadingParticleBiasing.hh
@@ -36,7 +36,7 @@ class G4VLeadingParticleBiasing
   public:
 
   G4VLeadingParticleBiasing() {};
-  ~G4VLeadingParticleBiasing() {};
+  virtual ~G4VLeadingParticleBiasing() {};
 
   virtual G4HadFinalState * Bias(G4HadFinalState * result) = 0;
 };


### PR DESCRIPTION
This is an attempt to fix Geant4 warning on top of #30. 