### PR TITLE
Fixed muon stopping

### DIFF
--- a/source/processes/hadronic/models/cascade/cascade/src/G4GDecay3.cc
+++ b/source/processes/hadronic/models/cascade/cascade/src/G4GDecay3.cc
@@ -42,15 +42,14 @@
 
 G4GDecay3::G4GDecay3(const G4double& pMass, const G4double& dMass0,
                      const G4double& dMass1, const G4double& dMass2)
- : loopMax(100), parentMass(pMass), mDaughter0(dMass0), mDaughter1(dMass1),
-   mDaughter2(dMass2), pDaughter0(0.), pDaughter1(0.), pDaughter2(0.) {;}
-
+ : loopMax(100), mDaughter0(dMass0), mDaughter1(dMass1),
+   mDaughter2(dMass2), pDaughter0(0.), pDaughter1(0.), pDaughter2(0.) 
+{
+  parentMass = std::max(pMass, mDaughter0 + mDaughter1 + mDaughter2 + CLHEP::keV);
+}
 
 G4bool G4GDecay3::CalculateMomentumMagnitudes()
 {
-  G4int looper = 0;
-  G4bool status;
-
   G4double rndm;
   G4double rndm1;
   G4double rndm2;
@@ -89,11 +88,9 @@ G4bool G4GDecay3::CalculateMomentumMagnitudes()
     pDaughter2 = std::sqrt(energy*energy + 2.0*energy*mDaughter2);
     if (pDaughter2 > momentummax) momentummax = pDaughter2;
     momentumsum += pDaughter2;
-    looper++;
-    status = looper < loopMax;
-  } while ((momentummax > momentumsum - momentummax) && status);
+  } while (momentummax > momentumsum - momentummax);
 
-  return status;
+  return true;
 }
 
 


### PR DESCRIPTION
In production with CMSSW_9_4_0_patch1 https://hypernews.cern.ch/HyperNews/CMS/get/prep-ops/5409.html a problem in Geant4 was reported. After investigation it turn out that there is rare problem in simulation of mu- absorption at rest  by the Bertini cascade, when kinematics of final state may be broken. The fix preserves the same method of sampling, so simulation history will not be changed until such rare event, for which the problem was observed. After such event the simulation history will diverse. So, in standard jenkins tests results should agree with the baseline due to limited statistic. No change of any physics observable is expected. The fix should be back ported to Geant4 10.2, whihc is used in CMSW_9_3_X and 9_4_X.