### PR TITLE
Fix FTFP_BERT_EMM Physics list for Geant4 11.0

### DIFF
--- a/source/processes/electromagnetic/utils/src/G4VMultipleScattering.cc
+++ b/source/processes/electromagnetic/utils/src/G4VMultipleScattering.cc
@@ -242,22 +242,21 @@ void G4VMultipleScattering::BuildPhysicsTable(const G4ParticleDefinition& part)
     */
     emManager->BuildPhysicsTable(firstParticle);
 
-    if(!master) {
       // initialisation of models
       /*
       std::cout << "### G4VMultipleScattering::BuildPhysicsTable() for "
                 << GetProcessName() << " and particle " << num
 		<< " Nmod= " << mscModels.size() << " NOT master" << std::endl;
       */
-      baseMat = masterProcess->UseBaseMaterial();
-      for(G4int i=0; i<numberOfModels; ++i) {
-	G4VMscModel* msc = GetModelByIndex(i);
-	if(nullptr == msc) { continue; }
-        G4VMscModel* msc0 = masterProcess->GetModelByIndex(i);
-        msc->SetUseBaseMaterials(baseMat);
-        msc->SetCrossSectionTable(msc0->GetCrossSectionTable(), false);
-        msc->InitialiseLocal(firstParticle, msc0);
-      }
+    baseMat = masterProcess->UseBaseMaterial();
+    for(G4int i=0; i<numberOfModels; ++i) {
+      G4VMscModel* msc = GetModelByIndex(i);
+      if(nullptr == msc) { continue; }
+      G4VMscModel* msc0 = masterProcess->GetModelByIndex(i);
+      msc->SetUseBaseMaterials(baseMat);
+      msc->SetCrossSectionTable(msc0->GetCrossSectionTable(), false);
+      msc->InitialiseLocal(firstParticle, msc0);
+      msc->SetIonisation(fIonisation, currParticle);
     }
   }
   // protection against double printout
@@ -312,7 +311,8 @@ void G4VMultipleScattering::StartTracking(G4Track* track)
          << G4LossTableManager::Instance()->IsMaster() 
          << G4endl;
   */
-  for(auto & msc : mscModels) {
+  for(G4int i=0; i<numberOfModels; ++i) {
+    G4VMscModel* msc = GetModelByIndex(i);
     /*
       G4cout << "Next model " << msc 
       << " Emin= " << msc->LowEnergyLimit() 


### PR DESCRIPTION
This is a critical fix for HCAL simulation with CMS default Physics List FTFP_BERT_EMM. The problem does not affect Physics Lists from Geant4 distribution. It exist in Geant4 11.0 and not in the master version.