### PR TITLE
Collection of fixes for Geant4 11.1

### DIFF
--- a/source/geometry/solids/Boolean/src/G4MultiUnion.cc
+++ b/source/geometry/solids/Boolean/src/G4MultiUnion.cc
@@ -480,6 +480,12 @@ EInside G4MultiUnion::InsideWithExclusion(const G4ThreeVector& aPoint,
   // located around will correspond to kInside (cf. G4UnionSolid)
 
   std::size_t size = surfaces.size();
+
+  if (size == 0)
+  {
+    return EInside::kOutside;
+  }
+
   for (std::size_t i = 0; i < size - 1; ++i)
   {
     G4MultiUnionSurface& left = surfaces[i];
@@ -494,9 +500,7 @@ EInside G4MultiUnion::InsideWithExclusion(const G4ThreeVector& aPoint,
     }
   }
 
-  location = size ? EInside::kSurface : EInside::kOutside;
-
-  return location;
+  return EInside::kSurface;
 }
 
 //______________________________________________________________________________

--- a/source/global/management/include/G4DataVector.hh
+++ b/source/global/management/include/G4DataVector.hh
@@ -70,7 +70,7 @@ class G4DataVector : public std::vector<G4double>
   inline void insertAt(std::size_t, const G4double&);
   // Insert an element at given position
 
-  inline std::size_t index(const G4double&);
+  inline std::size_t index(const G4double&) const;
   // Returns back index of the element same as given value
 
   inline G4bool contains(const G4double&) const;

--- a/source/global/management/include/G4DataVector.icc
+++ b/source/global/management/include/G4DataVector.icc
@@ -45,31 +45,22 @@ inline void G4DataVector::insertAt(std::size_t pos, const G4double& a)
   }
 }
 
-inline std::size_t G4DataVector::index(const G4double& a)
+inline std::size_t G4DataVector::index(const G4double& a) const
 {
   std::size_t ptn = 0;
   for(auto i = cbegin(); i != cend(); ++i, ++ptn)
   {
-    if(!(*i != a))
+    if((*i) == a)
     {
-      return ptn;
+      break;
     }
   }
-
-  return (ptn = ~(std::size_t) 0);
+  return ptn;
 }
 
 inline G4bool G4DataVector::contains(const G4double& a) const
 {
-  for(double i : *this)
-  {
-    if(!(i != a))
-    {
-      return true;
-    }
-  }
-
-  return false;
+  return (index(a) < size());
 }
 
 inline G4bool G4DataVector::remove(const G4double& a)

--- a/source/physics_lists/builders/OrderingParameterTable
+++ b/source/physics_lists/builders/OrderingParameterTable
@@ -7,16 +7,16 @@ PairProdCharged	2	4	-1	-1	4	0
 Annih		2	5	 5	-1	5	0
 AnnihToMuMu	2	6	-1	-1	6	0
 AnnihToHad	2	7	-1	-1	7	0
-NuclearStopp	2	8	-1	 8	-1	0
-ElectronSuper	2	9	-1	 1	1	0
+NuclearStopping	2	8	-1	 8	-1	0
+ElectronGeneral	2	9	-1	 1	1	0
 Msc		2	10	-1	 1	-1	0
 Rayleigh	2	11	-1	-1	1000	0	
 PhotoElectric	2	12	-1	-1	1000	0	
 Compton		2	13	-1	-1	1000	0
 Conv		2	14	-1	-1	1000	0	
 ConvToMuMu	2	15	-1	-1	1000	0
-GammaSuper	2	16	-1	-1	1000	0
-PositronSuper	2	17	 1	 1	1	0
+GammaGeneral	2	16	-1	-1	1000	0
+PositronGeneral	2	17	 1	 1	1	0
 Cerenkov	2	21	-1	-1	1000	0
 Scintillation	2	22	9999	-1	9999	0
 SynchRad	2	23	-1	-1	1000	0
@@ -28,6 +28,7 @@ OpRayleigh	3	33	-1	-1	1000	0
 OpWLS		3	34	-1	-1	1000	0
 OpMieHG		3	35	-1	-1	1000	0		
 OpWLS2		3	36	-1	-1	1000	0
+MuPairByMuon	2	49	-1	-1	1000	0
 DNAElastic 	2	51	-1	-1	1000	0	
 DNAExcit 	2	52	-1	-1	1000	0
 DNAIonisation 	2	53	-1	-1	1000	0
@@ -43,6 +44,7 @@ DNADoubleIoni 	2	62	-1	-1	1000	0
 DNADoubleCap 	2	63	-1	-1	1000	0
 DNAIoniTransfer 2	64	-1	-1	1000	0
 HadElastic	4	111	-1	-1	1000	0
+NeutronGeneral	4	116	-1	-1	1000	0
 HadInelastic	4	121	-1	-1	1000	0
 HadCapture	4	131	-1	-1	1000	0
 MuAtomCapture	4	132	-1	-1	1000	0
@@ -60,5 +62,4 @@ StepLimiter	7	401	-1	-1	1000	0
 UsrSpecCuts	7	402	-1	-1	1000	0
 NeutronKiller	7	403	-1	-1	1000	0
 ParallelWorld	10	491	9900	 1	9900	1
-
 

--- a/source/physics_lists/constructors/electromagnetic/src/G4GammaGeneralProcess.cc
+++ b/source/physics_lists/constructors/electromagnetic/src/G4GammaGeneralProcess.cc
@@ -604,6 +604,8 @@ G4VParticleChange* G4GammaGeneralProcess::PostStepDoIt(const G4Track& track,
       SelectEmProcess(step, theCompton);
     } else if(theRayleigh) {
       SelectEmProcess(step, theRayleigh);
+    } else {
+      SelectEmProcess(step, thePhotoElectric);
     }
     break;
 
@@ -616,6 +618,8 @@ G4VParticleChange* G4GammaGeneralProcess::PostStepDoIt(const G4Track& track,
       SelectEmProcess(step, thePhotoElectric);
     } else if(theGammaNuclear) {
       SelectHadProcess(track, step, theGammaNuclear);
+    } else {
+      SelectEmProcess(step, theConversionEE);
     }
     break;
 
@@ -630,6 +634,8 @@ G4VParticleChange* G4GammaGeneralProcess::PostStepDoIt(const G4Track& track,
       SelectHadProcess(track, step, theGammaNuclear);
     } else if(theConversionMM) {
       SelectedProcess(step, theConversionMM);
+    } else {
+      SelectEmProcess(step, theConversionEE);
     }
     break;
   }

--- a/source/physics_lists/util/src/G4HadProcesses.cc
+++ b/source/physics_lists/util/src/G4HadProcesses.cc
@@ -194,7 +194,6 @@ void G4HadProcesses::BuildNeutronInelasticAndCapture(G4HadronicProcess* nInel)
     auto neutron = G4Neutron::Neutron();
     G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
     nInel->AddDataSet(new G4NeutronInelasticXS());
-    nCap->AddDataSet(new G4NeutronCaptureXS());
     ph->RegisterProcess(nInel, neutron);
     ph->RegisterProcess(nCap, neutron);
     if( param->ApplyFactorXS() ) {

--- a/source/processes/electromagnetic/standard/include/G4GoudsmitSaundersonMscModel.hh
+++ b/source/processes/electromagnetic/standard/include/G4GoudsmitSaundersonMscModel.hh
@@ -277,7 +277,7 @@ void G4GoudsmitSaundersonMscModel::SetParticle(const G4ParticleDefinition* p)
 inline
 G4double G4GoudsmitSaundersonMscModel::Randomizetlimit()
 {
-  G4double temptlimit = tlimit;
+  G4double temptlimit;
     do {
          temptlimit = G4RandGauss::shoot(rndmEngineMod,tlimit,0.1*tlimit);
        } while ( (temptlimit<0.) || (temptlimit>2.*tlimit));

--- a/source/processes/hadronic/processes/include/G4NeutronGeneralProcess.hh
+++ b/source/processes/hadronic/processes/include/G4NeutronGeneralProcess.hh
@@ -57,6 +57,7 @@ class G4Track;
 class G4ParticleDefinition;
 class G4VParticleChange;
 class G4VCrossSectionDataSet;
+class G4CrossSectionDataStore;
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
@@ -102,11 +103,11 @@ public:
   // Temporary method
   G4int GetSubProcessSubType() const;
 
-  inline const G4VProcess* GetSelectedProcess() const;
+  void SetInelasticProcess(G4HadronicProcess*);
+  void SetElasticProcess(G4HadronicProcess*);
+  void SetCaptureProcess(G4HadronicProcess*);
 
-  inline void SetInelasticProcess(G4HadronicProcess*);
-  inline void SetElasticProcess(G4HadronicProcess*);
-  inline void SetCaptureProcess(G4HadronicProcess*);
+  inline const G4VProcess* GetSelectedProcess() const;
 
   inline void SetTimeLimit(G4double val);
 
@@ -125,15 +126,15 @@ protected:
   inline G4double GetProbability(size_t idxt);
 
   inline void SelectedProcess(const G4Step& step, G4HadronicProcess* ptr,
-                              G4VCrossSectionDataSet* xs);
-
-  void SelectHadProcess(const G4Track&, const G4Step&, G4HadronicProcess*);
+                              G4CrossSectionDataStore*);
 
 private:
 
   // partial cross section
   G4double ComputeCrossSection(G4VCrossSectionDataSet*, const G4Material*,
-                               G4double kinEnergy, G4double loge); 
+                               G4double kinEnergy, G4double loge);
+
+  G4VCrossSectionDataSet* InitialisationXS(G4HadronicProcess*);
 
   // total cross section
   inline void CurrentCrossSection(const G4Track&);
@@ -147,10 +148,14 @@ private:
   G4HadronicProcess* fCapture = nullptr;
   G4HadronicProcess* fSelectedProc = nullptr;
 
-  G4VCrossSectionDataSet* fInelasticXS;
-  G4VCrossSectionDataSet* fElasticXS;
-  G4VCrossSectionDataSet* fCaptureXS;
-  G4VCrossSectionDataSet* fXS = nullptr;
+  G4VCrossSectionDataSet* fInelasticXS = nullptr;
+  G4VCrossSectionDataSet* fElasticXS = nullptr;
+  G4VCrossSectionDataSet* fCaptureXS = nullptr;
+
+  G4CrossSectionDataStore* fXSSInelastic = nullptr;
+  G4CrossSectionDataStore* fXSSElastic = nullptr;
+  G4CrossSectionDataStore* fXSSCapture = nullptr;
+  G4CrossSectionDataStore* fCurrentXSS = nullptr;
 
   const G4ParticleDefinition* fNeutron;
   const G4Material* fCurrMat = nullptr;
@@ -178,31 +183,6 @@ private:
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
-inline void
-G4NeutronGeneralProcess::SetInelasticProcess(G4HadronicProcess* ptr)
-{
-  fInelastic = ptr;
-  ptr->AddDataSet(fInelasticXS);
-}
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
-
-inline void G4NeutronGeneralProcess::SetElasticProcess(G4HadronicProcess* ptr)
-{
-  fElastic = ptr;
-  ptr->AddDataSet(fElasticXS);
-}
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
-
-inline void G4NeutronGeneralProcess::SetCaptureProcess(G4HadronicProcess* ptr)
-{
-  fCapture = ptr;
-  ptr->AddDataSet(fCaptureXS);
-}
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
-
 inline G4double
 G4NeutronGeneralProcess::ComputeGeneralLambda(std::size_t idxe, std::size_t idxt)
 {
@@ -224,11 +204,11 @@ inline G4double G4NeutronGeneralProcess::GetProbability(std::size_t idxt)
 inline void
 G4NeutronGeneralProcess::SelectedProcess(const G4Step& step,
                                          G4HadronicProcess* ptr,
-                                         G4VCrossSectionDataSet* xs)
+                                         G4CrossSectionDataStore* xs)
 
 {
   fSelectedProc = ptr;
-  fXS = xs;
+  fCurrentXSS = xs;
   step.GetPostStepPoint()->SetProcessDefinedStep(ptr);
 }
 
@@ -245,18 +225,11 @@ inline void G4NeutronGeneralProcess::CurrentCrossSection(const G4Track& track)
 {
   G4double energy = track.GetKineticEnergy();
   const G4Material* mat = track.GetMaterial();
-  G4bool recompute = false;
-  if(mat != fCurrMat) {
+  if(mat != fCurrMat || energy != fCurrE) {
     fCurrMat = mat;
     matIndex = mat->GetIndex();
-    recompute = true;
-  }
-  if(energy != fCurrE) {
     fCurrE = energy;
     fCurrLogE = track.GetDynamicParticle()->GetLogKineticEnergy();
-    recompute = true;
-  }
-  if(recompute) {
     fLambda = (energy <= fMiddleEnergy) ? ComputeGeneralLambda(0, 0)
       : ComputeGeneralLambda(1, 3);
     currentInteractionLength = 1.0/fLambda;

--- a/source/processes/hadronic/processes/src/G4NeutronGeneralProcess.cc
+++ b/source/processes/hadronic/processes/src/G4NeutronGeneralProcess.cc
@@ -48,8 +48,8 @@
 #include "G4NeutronGeneralProcess.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
-#include "G4ProcessManager.hh"
 #include "G4HadronicProcess.hh"
+#include "G4CrossSectionDataStore.hh"
 #include "G4Step.hh"
 #include "G4Track.hh"
 #include "G4ParticleDefinition.hh"
@@ -62,7 +62,6 @@
 #include "G4MaterialTable.hh"
 #include "G4Element.hh"
 #include "G4Neutron.hh"
-#include "G4Nucleus.hh"
 #include "G4NeutronInelasticXS.hh"
 #include "G4NeutronElasticXS.hh"
 #include "G4NeutronCaptureXS.hh"
@@ -86,14 +85,6 @@ G4NeutronGeneralProcess::G4NeutronGeneralProcess(const G4String& pname)
 {
   SetVerboseLevel(1);
   SetProcessSubType(fNeutronGeneral);
-
-  fElasticXS = new G4NeutronElasticXS();
-  fInelasticXS = new G4NeutronInelasticXS();
-  fCaptureXS = new G4NeutronCaptureXS();
-
-  AddDataSet(fElasticXS);
-  AddDataSet(fInelasticXS);
-  AddDataSet(fCaptureXS);
 
   fNeutron = G4Neutron::Neutron();
 
@@ -120,6 +111,58 @@ G4bool G4NeutronGeneralProcess::IsApplicable(const G4ParticleDefinition&)
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void G4NeutronGeneralProcess::SetInelasticProcess(G4HadronicProcess* ptr)
+{
+  fInelastic = ptr;
+  fXSSInelastic = ptr->GetCrossSectionDataStore();
+  fInelasticXS = InitialisationXS(ptr);
+  if(nullptr == fInelasticXS) {
+    fInelasticXS = new G4NeutronInelasticXS();
+    ptr->AddDataSet(fInelasticXS);
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void G4NeutronGeneralProcess::SetElasticProcess(G4HadronicProcess* ptr)
+{
+  fElastic = ptr;
+  fXSSElastic = ptr->GetCrossSectionDataStore();
+  fElasticXS = InitialisationXS(ptr);
+  if(nullptr == fElasticXS) {
+    fElasticXS = new G4NeutronElasticXS();
+    ptr->AddDataSet(fElasticXS);
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+void G4NeutronGeneralProcess::SetCaptureProcess(G4HadronicProcess* ptr)
+{
+  fCapture = ptr;
+  fXSSCapture = ptr->GetCrossSectionDataStore();
+  fCaptureXS = InitialisationXS(ptr);
+  if(nullptr == fCaptureXS) {
+    fElasticXS = new G4NeutronCaptureXS();
+    ptr->AddDataSet(fCaptureXS);
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
+
+G4VCrossSectionDataSet*
+G4NeutronGeneralProcess::InitialisationXS(G4HadronicProcess* proc)
+{
+  G4VCrossSectionDataSet* ptr = nullptr;
+  auto xsv = proc->GetCrossSectionDataStore()->GetDataSetList();
+  if(!xsv.empty()) {
+    ptr = xsv[0];
+  }
+  return ptr;
+}
+
+//....Ooooo0ooooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....
 
 void G4NeutronGeneralProcess::PreparePhysicsTable(const G4ParticleDefinition& part)
 {
@@ -211,7 +254,6 @@ void G4NeutronGeneralProcess::BuildPhysicsTable(const G4ParticleDefinition& part
   fElastic->BuildPhysicsTable(part);
   fInelastic->BuildPhysicsTable(part);
   fCapture->BuildPhysicsTable(part);
-  fCaptureXS->BuildPhysicsTable(part);
 
   if(isMaster) {
     std::size_t nmat = G4Material::GetNumberOfMaterials();
@@ -349,7 +391,7 @@ G4double G4NeutronGeneralProcess::PostStepGetPhysicalInteractionLength(
 G4VParticleChange* G4NeutronGeneralProcess::PostStepDoIt(const G4Track& track,
                                                          const G4Step& step)
 {
-  fSelectedProc = nullptr;
+  fSelectedProc = this;
   // time limit
   if(0.0 == fLambda) {
     theTotalResult->Initialize(track);
@@ -365,46 +407,26 @@ G4VParticleChange* G4NeutronGeneralProcess::PostStepDoIt(const G4Track& track,
   */
   if (0 == idxEnergy) {
     if(q <= GetProbability(1)) {
-      SelectedProcess(step, fElastic, fElasticXS);
+      SelectedProcess(step, fElastic, fXSSElastic);
     } else if(q <= GetProbability(2)) {
-      SelectedProcess(step, fInelastic, fInelasticXS);
+      SelectedProcess(step, fInelastic, fXSSInelastic);
     } else {
-      SelectedProcess(step, fCapture, fCaptureXS);
+      SelectedProcess(step, fCapture, fXSSCapture);
     }
   } else {
     if(q <= GetProbability(4)) {
-      SelectedProcess(step, fInelastic, fInelasticXS);
+      SelectedProcess(step, fInelastic, fXSSInelastic);
     } else {
-      SelectedProcess(step, fElastic, fElasticXS);
+      SelectedProcess(step, fElastic, fXSSElastic);
     }
   }
-  const G4Element* elm = fCurrMat->GetElement(0);
-  G4int nelm = (G4int)fCurrMat->GetNumberOfElements();
-  if(1 < nelm) {
-    auto natom = fCurrMat->GetVecNbOfAtomsPerVolume();
-    G4double sig = 0.0;
-    for(G4int i=0; i<nelm; ++i) {
-      sig += natom[i] *
-        fXS->ComputeCrossSectionPerElement(fCurrE, fCurrLogE, fNeutron,
-                                           fCurrMat->GetElement(i),
-                                           fCurrMat);
-      fXsec[i] = sig;
-    }
-    sig *= G4UniformRand();
-    for(G4int i=0; i<nelm; ++i) {
-      if(fXsec[i] >= sig) {
-        elm = fCurrMat->GetElement(i);
-        break;
-      }
-    }
+  // total cross section is needed for selection of an element
+  if(fCurrMat->GetNumberOfElements() > 1) {
+    fCurrentXSS->ComputeCrossSection(track.GetDynamicParticle(), fCurrMat);
   }
-  fSelectedProc->GetCrossSectionDataStore()->SetForcedElement(elm);
-  const G4Isotope* iso = fXS->SelectIsotope(elm, fCurrE, fCurrLogE);
-  fSelectedProc->GetTargetNucleusPointer()->SetIsotope(iso);
   /*
-  G4cout << "## neutron E(MeV)=" << fCurrE << "  " 
+    G4cout << "## neutron E(MeV)=" << fCurrE << " inside " << fCurrMat->GetName() 
 	 << fSelectedProc->GetProcessName()
-	 << " on Z=" << iso->GetZ() << " A=" << iso->GetN() 
 	 << " time(ns)=" << track.GetGlobalTime()/ns << G4endl; 
   */
   // sample secondaries
@@ -457,7 +479,7 @@ void G4NeutronGeneralProcess::ProcessDescription(std::ostream& out) const
 
 const G4String& G4NeutronGeneralProcess::GetSubProcessName() const
 {
-  return (fSelectedProc) ? fSelectedProc->GetProcessName()
+  return (nullptr != fSelectedProc) ? fSelectedProc->GetProcessName()
     : G4VProcess::GetProcessName();
 }
 
@@ -465,7 +487,8 @@ const G4String& G4NeutronGeneralProcess::GetSubProcessName() const
 
 G4int G4NeutronGeneralProcess::GetSubProcessSubType() const
 {
-  return (fSelectedProc) ? fSelectedProc->GetProcessSubType() : 16;
+  return (nullptr != fSelectedProc) ? fSelectedProc->GetProcessSubType()
+    : fNeutronGeneral;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo....

--- a/source/run/src/G4PhysicsListHelper.cc
+++ b/source/run/src/G4PhysicsListHelper.cc
@@ -734,7 +734,7 @@ void G4PhysicsListHelper::ReadInDefaultOrderingParameter()
   theTable->push_back(tmp);
   sizeOfTable += 1;
 
-  tmp.processTypeName = "NuclearStopp";
+  tmp.processTypeName = "NuclearStopping";
   tmp.processType     = fElectromagnetic;
   tmp.processSubType  = fNuclearStopping;
   tmp.ordering[0]     = -1;
@@ -744,7 +744,7 @@ void G4PhysicsListHelper::ReadInDefaultOrderingParameter()
   theTable->push_back(tmp);
   sizeOfTable += 1;
 
-  tmp.processTypeName = "ElectronSuper";
+  tmp.processTypeName = "ElectronGeneral";
   tmp.processType     = fElectromagnetic;
   tmp.processSubType  = fElectronGeneralProcess;
   tmp.ordering[0]     = -1;
@@ -814,7 +814,7 @@ void G4PhysicsListHelper::ReadInDefaultOrderingParameter()
   theTable->push_back(tmp);
   sizeOfTable += 1;
 
-  tmp.processTypeName = "GammaSuper";
+  tmp.processTypeName = "GammaGeneral";
   tmp.processType     = fElectromagnetic;
   tmp.processSubType  = fGammaGeneralProcess;
   tmp.ordering[0]     = -1;
@@ -824,12 +824,22 @@ void G4PhysicsListHelper::ReadInDefaultOrderingParameter()
   theTable->push_back(tmp);
   sizeOfTable += 1;
 
-  tmp.processTypeName = "PositronSuper";
+  tmp.processTypeName = "PositronGeneral";
   tmp.processType     = fElectromagnetic;
   tmp.processSubType  = fPositronGeneralProcess;
   tmp.ordering[0]     = 1;
   tmp.ordering[1]     = 1;
   tmp.ordering[2]     = 1;
+  tmp.isDuplicable    = false;
+  theTable->push_back(tmp);
+  sizeOfTable += 1;
+
+  tmp.processTypeName = "MuPairByMuon";
+  tmp.processType     = fElectromagnetic;
+  tmp.processSubType  = fMuonPairProdByCharged;
+  tmp.ordering[0]     = 1;
+  tmp.ordering[1]     = 1;
+  tmp.ordering[2]     = 1000;
   tmp.isDuplicable    = false;
   theTable->push_back(tmp);
   sizeOfTable += 1;
@@ -1107,6 +1117,16 @@ void G4PhysicsListHelper::ReadInDefaultOrderingParameter()
   tmp.processTypeName = "HadElastic";
   tmp.processType     = fHadronic;
   tmp.processSubType  = fHadronElastic;
+  tmp.ordering[0]     = -1;
+  tmp.ordering[1]     = -1;
+  tmp.ordering[2]     = 1000;
+  tmp.isDuplicable    = false;
+  theTable->push_back(tmp);
+  sizeOfTable += 1;
+
+  tmp.processTypeName = "NeutronGeneral";
+  tmp.processType     = fHadronic;
+  tmp.processSubType  = fNeutronGeneral;
   tmp.ordering[0]     = -1;
   tmp.ordering[1]     = -1;
   tmp.ordering[2]     = 1000;


### PR DESCRIPTION
Proposed number of fixes on top of the new Geant4 11.1 for early testing within CMSSW. Most of these fixes are technical. Essential for CMS simulation:

1) G4GammaGeneralProcess - avoid rare cases when concrete Geant4 process is not chosen due to inaccurate arithmetics.
2) G4NeutronGeneralProcess - removed unnecessary double computation of cross section.
3) Added to the list of processes forgotten new process of muon pair production by muons

In general, this patch may change simulation history but for some WF regression may be preserved due to limited statistics.

After merge of this  PR new PRs to use updated Geant4 11.1 should be created for GEANT4 and G4VECGEOM branches of CMSSW.

