### PR TITLE
Fixed run time problem in hadron elastic process

### DIFF
--- a/source/processes/hadronic/management/include/G4HadronicProcess.hh
+++ b/source/processes/hadronic/management/include/G4HadronicProcess.hh
@@ -210,16 +210,20 @@ private:
   G4double XBiasSurvivalProbability();
   G4double XBiasSecondaryWeight();
 
-  // Set E/p conservation check levels from environment variables
-  void GetEnergyMomentumCheckEnvvars();
-
 protected:
 
   G4HadProjectile thePro;
 
   G4ParticleChange* theTotalResult;
+  G4CrossSectionDataStore* theCrossSectionDataStore;
+
   G4double fWeight = 1.0;
-  G4long epReportLevel = 0;
+  G4double aScaleFactor = 1.0;
+  G4double theLastCrossSection = 0.0;
+  G4double mfpKinEnergy = DBL_MAX;
+  G4int epReportLevel = 0;
+
+  G4HadXSType fXSType = fHadNoIntegral;
 
 private:
     
@@ -227,7 +231,6 @@ private:
   G4Nucleus targetNucleus;
     
   G4HadronicInteraction* theInteraction = nullptr;
-  G4CrossSectionDataStore* theCrossSectionDataStore;
   G4HadronicProcessStore* theProcessStore;
   const G4HadronicProcess* masterProcess = nullptr;
   const G4ParticleDefinition* firstParticle = nullptr;
@@ -237,14 +240,11 @@ private:
 
   std::vector<G4double>* theEnergyOfCrossSectionMax = nullptr;
   std::vector<G4TwoPeaksHadXS*>* fXSpeaks = nullptr;
+
+  const char* fRandomFile = nullptr;
      
-  G4double aScaleFactor = 1.0;
-  G4double theLastCrossSection = 0.0;
-  G4double mfpKinEnergy = DBL_MAX;
   G4double theMFP = DBL_MAX;
   G4double minKinEnergy;
-
-  G4HadXSType fXSType = fHadNoIntegral;
 
   // counters
   G4int nMatWarn = 0;
@@ -254,7 +254,7 @@ private:
 
   // flags
   G4bool levelsSetByProcess = false;
-  G4bool G4HadronicProcess_debug_flag = false;
+  G4bool fDebugFlag = false;
   G4bool useIntegralXS = true;
   G4bool isMaster = true;
 
@@ -347,7 +347,7 @@ G4HadronicProcess::TwoPeaksXS() const
 inline std::vector<G4double>*
 G4HadronicProcess::EnergyOfCrossSectionMax() const
 {
-  return  theEnergyOfCrossSectionMax;
+  return theEnergyOfCrossSectionMax;
 }
 
 inline G4HadronicInteraction* G4HadronicProcess::

--- a/source/processes/hadronic/management/include/G4HadronicProcess.hh
+++ b/source/processes/hadronic/management/include/G4HadronicProcess.hh
@@ -224,7 +224,7 @@ protected:
   G4double aScaleFactor = 1.0;
   G4double theLastCrossSection = 0.0;
   G4double mfpKinEnergy = DBL_MAX;
-  G4int epReportLevel = 0;
+  G4long epReportLevel = 0;
 
   G4HadXSType fXSType = fHadNoIntegral;
 

--- a/source/processes/hadronic/management/include/G4HadronicProcess.hh
+++ b/source/processes/hadronic/management/include/G4HadronicProcess.hh
@@ -244,8 +244,6 @@ private:
   std::vector<G4double>* theEnergyOfCrossSectionMax = nullptr;
   std::vector<G4TwoPeaksHadXS*>* fXSpeaks = nullptr;
 
-  const char* RandomFile = nullptr;
-     
   G4double theMFP = DBL_MAX;
   G4double minKinEnergy;
 

--- a/source/processes/hadronic/management/include/G4HadronicProcess.hh
+++ b/source/processes/hadronic/management/include/G4HadronicProcess.hh
@@ -210,6 +210,9 @@ private:
   G4double XBiasSurvivalProbability();
   G4double XBiasSecondaryWeight();
 
+  // Set E/p conservation check levels from environment variables
+  void GetEnergyMomentumCheckEnvvars();
+
 protected:
 
   G4HadProjectile thePro;
@@ -241,7 +244,7 @@ private:
   std::vector<G4double>* theEnergyOfCrossSectionMax = nullptr;
   std::vector<G4TwoPeaksHadXS*>* fXSpeaks = nullptr;
 
-  const char* fRandomFile = nullptr;
+  const char* RandomFile = nullptr;
      
   G4double theMFP = DBL_MAX;
   G4double minKinEnergy;
@@ -254,7 +257,7 @@ private:
 
   // flags
   G4bool levelsSetByProcess = false;
-  G4bool fDebugFlag = false;
+  G4bool G4HadronicProcess_debug_flag = false;
   G4bool useIntegralXS = true;
   G4bool isMaster = true;
 

--- a/source/processes/hadronic/processes/src/G4HadronElasticProcess.cc
+++ b/source/processes/hadronic/processes/src/G4HadronElasticProcess.cc
@@ -68,30 +68,42 @@ G4HadronElasticProcess::PostStepDoIt(const G4Track& track,
   theTotalResult->ProposeWeight(weight);
 
   // For elastic scattering, _any_ result is considered an interaction
-  ClearNumberOfInteractionLengthLeft();
+  theNumberOfInteractionLengthLeft = -1.0;
+  //  ClearNumberOfInteractionLengthLeft();
 
-  G4double kineticEnergy = track.GetKineticEnergy();
+  const G4DynamicParticle* dynParticle = track.GetDynamicParticle();
+  G4double kineticEnergy = dynParticle->GetKineticEnergy();
   G4TrackStatus status = track.GetTrackStatus();
   if(kineticEnergy == 0.0 || track.GetTrackStatus() != fAlive) {
     return theTotalResult;
   }
 
-  const G4DynamicParticle* dynParticle = track.GetDynamicParticle();
-  const G4ParticleDefinition* part = dynParticle->GetDefinition();
   const G4Material* material = track.GetMaterial();
+
+  // check only for charged particles
+  if(fXSType != fHadNoIntegral) {
+    mfpKinEnergy = DBL_MAX;
+    G4double xs = aScaleFactor*
+      theCrossSectionDataStore->ComputeCrossSection(dynParticle, material);
+    if(xs < theLastCrossSection*G4UniformRand()) {
+      // No interaction
+      return theTotalResult;
+    }    
+  }
+
+  const G4ParticleDefinition* part = dynParticle->GetDefinition();
   G4Nucleus* targNucleus = GetTargetNucleusPointer();
 
   // Select element
   const G4Element* elm = 
-    GetCrossSectionDataStore()->SampleZandA(dynParticle, material, *targNucleus);
+    theCrossSectionDataStore->SampleZandA(dynParticle, material, *targNucleus);
 
   // Initialize the hadronic projectile from the track
   G4HadProjectile theProj(track);
   G4HadronicInteraction* hadi = nullptr;
   G4HadFinalState* result = nullptr;
 
-  if(fDiffraction) 
-  {
+  if(nullptr != fDiffraction) {
     G4double ratio = 
       fDiffractionRatio->ComputeRatio(part, kineticEnergy,
 				      targNucleus->GetZ_asInt(),
@@ -108,7 +120,8 @@ G4HadronElasticProcess::PostStepDoIt(const G4Track& track,
 	  G4ExceptionDescription ed;
 	  aR.Report(ed);
 	  ed << "Call for " << fDiffraction->GetModelName() << G4endl;
-	  ed << "Target element "<< elm->GetName()<<"  Z= " 
+	  ed << part->GetParticleName() 
+	     << " off target element " << elm->GetName() << "  Z= " 
 	     << targNucleus->GetZ_asInt() 
 	     << "  A= " << targNucleus->GetA_asInt() << G4endl;
 	  DumpState(track,"ApplyYourself",ed);
@@ -118,9 +131,7 @@ G4HadronElasticProcess::PostStepDoIt(const G4Track& track,
 	}
       // Check the result for catastrophic energy non-conservation
       result = CheckResult(theProj, *targNucleus, result);
-
       result->SetTrafoToLab(theProj.GetTrafoToLab());
-      ClearNumberOfInteractionLengthLeft();
 
       // The following method of the base class takes care also of setting
       // the creator model ID for the secondaries that are created
@@ -134,28 +145,24 @@ G4HadronElasticProcess::PostStepDoIt(const G4Track& track,
   }      
 
   // ordinary elastic scattering
-  try
-    {
-      hadi = ChooseHadronicInteraction( theProj, *targNucleus, material, elm );
-    }
-  catch(G4HadronicException & aE)
-    {
-      G4ExceptionDescription ed;
-      aE.Report(ed);
-      ed << "Target element "<< elm->GetName()<<"  Z= " 
-	 << targNucleus->GetZ_asInt() << "  A= " 
-	 << targNucleus->GetA_asInt() << G4endl;
-      DumpState(track,"ChooseHadronicInteraction",ed);
-      ed << " No HadronicInteraction found out" << G4endl;
-      G4Exception("G4HadronElasticProcess::PostStepDoIt", "had005", 
-		  FatalException, ed);
-    }
+  hadi = ChooseHadronicInteraction( theProj, *targNucleus, material, elm );
+  if(nullptr == hadi) {
+    G4ExceptionDescription ed;
+    ed << part->GetParticleName() 
+       << " off target element " << elm->GetName() << "  Z= " 
+       << targNucleus->GetZ_asInt() << "  A= " 
+       << targNucleus->GetA_asInt() << G4endl;
+    DumpState(track,"ChooseHadronicInteraction",ed);
+    ed << " No HadronicInteraction found out" << G4endl;
+    G4Exception("G4HadronElasticProcess::PostStepDoIt", "had005", 
+		FatalException, ed);
+  }
 
   size_t idx = track.GetMaterialCutsCouple()->GetIndex();
   G4double tcut = (*(G4ProductionCutsTable::GetProductionCutsTable()
 		     ->GetEnergyCutsVector(3)))[idx];
   hadi->SetRecoilEnergyThreshold(tcut);
-
+  /*
   if(verboseLevel>1) {
     G4cout << "G4HadronElasticProcess::PostStepDoIt for " 
 	   << part->GetParticleName()
@@ -164,24 +171,8 @@ G4HadronElasticProcess::PostStepDoIt(const G4Track& track,
 	   << " A= " << targNucleus->GetA_asInt() 
 	   << " Tcut(MeV)= " << tcut << G4endl; 
   }
-
-  try
-    {
-      result = hadi->ApplyYourself( theProj, *targNucleus);
-    }
-  catch(G4HadronicException & aR)
-    {
-      G4ExceptionDescription ed;
-      aR.Report(ed);
-      ed << "Call for " << hadi->GetModelName() << G4endl;
-      ed << "Target element "<< elm->GetName()<<"  Z= " 
-	 << targNucleus->GetZ_asInt() 
-	 << "  A= " << targNucleus->GetA_asInt() << G4endl;
-      DumpState(track,"ApplyYourself",ed);
-      ed << " ApplyYourself failed" << G4endl;
-      G4Exception("G4HadronElasticProcess::PostStepDoIt", "had006", 
-		  FatalException, ed);
-    }
+  */
+  result = hadi->ApplyYourself( theProj, *targNucleus);
 
   // Check the result for catastrophic energy non-conservation
   // cannot be applied because is not guranteed that recoil 
@@ -191,7 +182,7 @@ G4HadronElasticProcess::PostStepDoIt(const G4Track& track,
   // directions
   G4ThreeVector indir = track.GetMomentumDirection();
   G4ThreeVector outdir = result->GetMomentumChange();
-
+  /*
   if(verboseLevel>1) {
     G4cout << "Efin= " << result->GetEnergyChange()
 	   << " de= " << result->GetLocalEnergyDeposit()
@@ -199,7 +190,7 @@ G4HadronElasticProcess::PostStepDoIt(const G4Track& track,
 	   << " dir= " << outdir
 	   << G4endl;
   }
-
+  */
   // energies  
   G4double edep = std::max(result->GetLocalEnergyDeposit(), 0.0);
   G4double efinal = std::max(result->GetEnergyChange(), 0.0);

--- a/source/processes/transportation/src/G4CoupledTransportation.cc
+++ b/source/processes/transportation/src/G4CoupledTransportation.cc
@@ -380,13 +380,13 @@ AlongStepGetPhysicalInteractionLength( const G4Track&  track,
           //
           fEndGlobalTimeComputed = false;
   
+#ifdef G4VERBOSE
           // Check that the integration preserved the energy 
           //     -  and if not correct this!
           G4double  startEnergy= track.GetKineticEnergy();
           G4double  endEnergy= fTransportEndKineticEnergy; 
       
           G4double absEdiff = std::fabs(startEnergy- endEnergy);
-#ifdef G4VERBOSE
           if( (verboseLevel > 1) && ( absEdiff > perThousand * endEnergy) )
           {
             ReportInexactEnergy(startEnergy, endEnergy); 


### PR DESCRIPTION
Two fixes are added, which are available in Geant4 master:
1) fixed run time computations for hadron elastic process
2) fixed warning on "unused variable" in G4CoupledTransportation

Both are useful for CMSSW.