### PR TITLE
Fixed warnings for LTO build of biglib

### DIFF
--- a/source/geometry/solids/specific/src/G4VTwistSurface.cc
+++ b/source/geometry/solids/specific/src/G4VTwistSurface.cc
@@ -715,7 +715,7 @@ G4ThreeVector G4VTwistSurface::GetBoundaryAtPZ(G4int areacode,
 
    G4ThreeVector d;
    G4ThreeVector x0;
-   G4int         boundarytype;
+   G4int         boundarytype = 0;
    G4bool        found = false;
    
    for (G4int i=0; i<4; ++i)

--- a/source/processes/hadronic/models/lend/src/MCGIDI_energy.cc
+++ b/source/processes/hadronic/models/lend/src/MCGIDI_energy.cc
@@ -310,7 +310,8 @@ err:
 static int MCGIDI_energy_parseMadlandNixFromTOM( statusMessageReporting *smr, xDataTOM_element *functional, MCGIDI_energy *energy ) {
 
     int iE, length, nXs, i1, n;
-    double E, T_M, EFL, EFH, argList[3], xs[] = { 1e-5, 1e-3, 1e-1, 1e1, 1e3, 1e5, 3e7 }, norm;
+    double E=0., T_M=0., EFL=0., EFH=0., argList[3] = { 0., 0., 0. },
+           xs[] = { 1e-5, 1e-3, 1e-1, 1e1, 1e3, 1e5, 3e7 }, norm;
     ptwXYPoints *ptwXY_TM = NULL, *pdfXY = NULL;
     ptwXYPoint *point;
     ptwXPoints *cdfX = NULL;
@@ -419,7 +420,7 @@ static nfu_status MCGIDI_energy_parseMadlandNixFromTOM_callback( double Ep, doub
 */
 static double MCGIDI_energy_parseMadlandNixFromTOM_callback_g( double Ep, double E_F, double T_M, nfu_status *status ) {
 
-    double u1, u2, E1, E2, gamma1, gamma2, signG = 1;
+    double u1, u2, E1, E2 = 0., gamma1 = 0., gamma2 = 0., signG = 1;
 
     u1 = std::sqrt( Ep ) - std::sqrt( E_F );
     u1 *= u1 / T_M;
@@ -612,7 +613,7 @@ static int MCGIDI_energy_sampleWatt( statusMessageReporting * /*smr*/, double e_
 /*
 *   From MCAPM via Sample Watt Spectrum as in TART ( Kalos algorithm ).
 */
-    double WattMin = 0., WattMax = e_in_U, x, y, z, energyOut, rand1, rand2;
+    double WattMin = 0., WattMax = e_in_U, x, y, z, energyOut = 0., rand1, rand2;
 
     x = 1. + ( Watt_b / ( 8. * Watt_a ) );
     y = ( x + std::sqrt( x * x - 1. ) ) / Watt_a;

--- a/source/processes/hadronic/models/particle_hp/include/G4ParticleHPDeExGammas.hh
+++ b/source/processes/hadronic/models/particle_hp/include/G4ParticleHPDeExGammas.hh
@@ -42,35 +42,30 @@
 
 class G4ParticleHPDeExGammas
 {
-  public:
+public:
   
   G4ParticleHPDeExGammas() 
   {
-    levelStart = 0;
-    levelSize = 0;
-    nLevels = 0;
-    theLevels = 0;
   }
   ~G4ParticleHPDeExGammas() 
   {
-    if(levelStart!=0) delete [] levelStart;
-    if(levelSize!=0) delete [] levelSize;
-    if(theLevels!=0) delete [] theLevels;
+    delete [] levelStart;
+    delete [] levelSize;
+    delete [] theLevels;
   }
   
   void Init(std::istream & aDataFile);
 
   inline G4ReactionProductVector * GetDecayGammas(G4int aLevel)
   {
-    if(aLevel>nLevels-1 || aLevel<0) return 0;
+    if(aLevel>nLevels-1 || aLevel<0) return nullptr;
     if(nLevels==0) return new G4ReactionProductVector();
     G4ReactionProductVector * result = new G4ReactionProductVector;
     G4DynamicParticleVector * theResult;
 
     theResult = theLevels[aLevel]. GetDecayGammas();
     G4ReactionProduct * theCurrent;
-    unsigned int i;
-    for(i=0; i<theResult->size(); i++)
+    for(unsigned int i=0; i<theResult->size(); ++i)
     {
       theCurrent = new G4ReactionProduct;
       *theCurrent = *(theResult->operator[](i));
@@ -90,8 +85,7 @@ class G4ParticleHPDeExGammas
   
   inline G4ParticleHPLevel * GetLevel(G4int i)
   {
-    if(std::getenv("G4PHPTEST")) G4cout << this << " GetLEVEL " << i << " n " << nLevels << G4endl;
-    if(i>nLevels-1) return 0;
+    if(i>nLevels-1) return nullptr;
     return theLevels+i;
   }
   
@@ -105,10 +99,10 @@ class G4ParticleHPDeExGammas
   }
   private:
   
-  G4int * levelStart;
-  G4int * levelSize;
-  G4int nLevels;
-  G4ParticleHPLevel * theLevels;
+  G4int * levelStart = nullptr;
+  G4int * levelSize = nullptr;
+  G4int nLevels = 0;
+  G4ParticleHPLevel * theLevels = nullptr;
 };
 
 #endif

--- a/source/processes/hadronic/models/particle_hp/include/G4ParticleHPGamma.hh
+++ b/source/processes/hadronic/models/particle_hp/include/G4ParticleHPGamma.hh
@@ -39,10 +39,10 @@
 
 class G4ParticleHPGamma
 {
-  public:
+public:
   
   G4ParticleHPGamma();
-  ~G4ParticleHPGamma();
+  ~G4ParticleHPGamma() = default;
   
   G4bool Init(std::istream & aDataFile);
   
@@ -84,14 +84,13 @@ class G4ParticleHPGamma
     return probability;
   }
 
-  private:
+private:
   
   G4double levelEnergy;
   G4double gammaEnergy;
   G4double probability;
   
   G4ParticleHPLevel * next;
-  static G4ThreadLocal int instancecount;
 };
 
 #endif

--- a/source/processes/hadronic/models/particle_hp/src/G4ParticleHPDeExGammas.cc
+++ b/source/processes/hadronic/models/particle_hp/src/G4ParticleHPDeExGammas.cc
@@ -111,7 +111,7 @@ void G4ParticleHPDeExGammas::Init(std::istream & aDataFile)
     }
   }
 
-// set the next relation in the gammas.
+  // set the next relation in the gammas.
   G4double levelE, gammaE, currentLevelE;
   G4double min; 
   for(i=0; i<nGammas; i++)

--- a/source/processes/hadronic/models/particle_hp/src/G4ParticleHPGamma.cc
+++ b/source/processes/hadronic/models/particle_hp/src/G4ParticleHPGamma.cc
@@ -32,18 +32,13 @@
 #include "G4ParticleHPGamma.hh"
 #include "G4SystemOfUnits.hh"
 
-G4ThreadLocal int G4ParticleHPGamma::instancecount = 0;
-
-  G4ParticleHPGamma::G4ParticleHPGamma() 
-  {
-    next = 0;
-    instancecount ++;
-    levelEnergy = 0.0;
-    gammaEnergy = 0.0;
-    probability = 0.0;
-  }
-
-  G4ParticleHPGamma::~G4ParticleHPGamma() {instancecount--;}
+G4ParticleHPGamma::G4ParticleHPGamma() 
+{
+  next = 0;
+  levelEnergy = 0.0;
+  gammaEnergy = 0.0;
+  probability = 0.0;
+}
 
 G4bool G4ParticleHPGamma::Init(std::istream & aDataFile)
 {

--- a/source/processes/hadronic/models/particle_hp/src/G4ParticleHPLevel.cc
+++ b/source/processes/hadronic/models/particle_hp/src/G4ParticleHPLevel.cc
@@ -32,58 +32,58 @@
 #include "G4ParticleHPLevel.hh"
 #include "G4ParticleHPGamma.hh"
 
-  G4ParticleHPLevel::~G4ParticleHPLevel() 
-  {
-    if(theGammas != 0)
+G4ParticleHPLevel::~G4ParticleHPLevel() 
+{
+  if(theGammas != 0)
     {
       for(G4int i=0; i<nGammas; i++) delete theGammas[i];
+      delete [] theGammas;
     }
-    delete [] theGammas;
-  }
+}
 
-  void G4ParticleHPLevel::SetNumberOfGammas(G4int aGammas)
-  {
-    nGammas = aGammas;
-    if(theGammas != 0)
+void G4ParticleHPLevel::SetNumberOfGammas(G4int aGammas)
+{
+  nGammas = aGammas;
+  if(theGammas != 0)
     {
       for(G4int i=0; i<nGammas; i++) delete theGammas[i];
+      delete [] theGammas; 
     }
-    delete [] theGammas; 
-    theGammas = new G4ParticleHPGamma * [nGammas];
-  }
+  theGammas = new G4ParticleHPGamma * [nGammas];
+}
 
-  void G4ParticleHPLevel::SetGamma(G4int i, G4ParticleHPGamma * aGamma)
-  {
-    theGammas[i] = aGamma;
-    SetLevelEnergy(aGamma->GetLevelEnergy());
-  }
+void G4ParticleHPLevel::SetGamma(G4int i, G4ParticleHPGamma * aGamma)
+{
+  theGammas[i] = aGamma;
+  SetLevelEnergy(aGamma->GetLevelEnergy());
+}
 
-  G4double G4ParticleHPLevel::GetGammaEnergy(G4int i)
-  {
-    return theGammas[i]->GetGammaEnergy();
-  }
+G4double G4ParticleHPLevel::GetGammaEnergy(G4int i)
+{
+  return theGammas[i]->GetGammaEnergy();
+}
   
-  G4DynamicParticleVector * G4ParticleHPLevel::GetDecayGammas()
-  {
-    G4DynamicParticleVector * theResult;
-    G4double sum = 0;
-    G4double * running = new G4double[nGammas];
-    running[0] = 0;
-    G4int i;
-    for(i=0; i<nGammas; i++)
+G4DynamicParticleVector * G4ParticleHPLevel::GetDecayGammas()
+{
+  G4DynamicParticleVector * theResult;
+  G4double sum = 0;
+  G4double * running = new G4double[nGammas];
+  running[0] = 0;
+  G4int i;
+  for(i=0; i<nGammas; i++)
     {
       if(i!=0) running[i]=running[i-1];
       running[i]+=theGammas[i]->GetWeight();
     }
-    sum = running[nGammas-1];
-    G4int it(0);
-    G4double random = G4UniformRand();
-    for(i=0; i<nGammas; i++)
+  sum = running[nGammas-1];
+  G4int it(0);
+  G4double random = G4UniformRand();
+  for(i=0; i<nGammas; i++)
     {
       it = i;
       if(random*sum < running[i]) break;
     }
-    delete [] running;
-    theResult = theGammas[it]->GetDecayGammas();
-    return theResult;
-  }
+  delete [] running;
+  theResult = theGammas[it]->GetDecayGammas();
+  return theResult;
+}

--- a/source/processes/hadronic/models/parton_string/qgsm/src/G4QGSMSplitableHadron.cc
+++ b/source/processes/hadronic/models/parton_string/qgsm/src/G4QGSMSplitableHadron.cc
@@ -225,8 +225,8 @@ void G4QGSMSplitableHadron::GetValenceQuarkFlavors(const G4ParticleDefinition * 
                                                    G4Parton *& Parton1, G4Parton *& Parton2)
 {
   // Note! convention aEnd = q or (qq)bar and bEnd = qbar or qq.
-  G4int aEnd;
-  G4int bEnd;
+  G4int aEnd = 0;
+  G4int bEnd = 0;
   G4int HadronEncoding = aPart->GetPDGEncoding();
   if (aPart->GetBaryonNumber() == 0)
   {


### PR DESCRIPTION
This PR is needed to fix compilation warnings in Geant4 when biglib is built. These warnings happens in the classes, which are not used in standard CMSSW WFs, so no change of results are expected.