### PR TITLE
G4TransportationWithMsc: Always update momentum direction

### DIFF
--- a/source/processes/electromagnetic/utils/src/G4TransportationWithMsc.cc
+++ b/source/processes/electromagnetic/utils/src/G4TransportationWithMsc.cc
@@ -372,8 +372,7 @@ G4double G4TransportationWithMsc::AlongStepGetPhysicalInteractionLength(
             // 2) Call SampleScattering(), which *may* change it.
             const G4ThreeVector displacement =
               mscModel->SampleScattering(fTransportEndMomentumDir, minSafety);
-            // 3) Get the changed direction and inform G4Transportation.
-            fMomentumChanged         = true;
+            // 3) Get the changed direction.
             fTransportEndMomentumDir = *fParticleChangeForMSC->GetProposedMomentumDirection();
 
             const G4double r2 = displacement.mag2();
@@ -468,6 +467,12 @@ G4double G4TransportationWithMsc::AlongStepGetPhysicalInteractionLength(
         }
 
         fParticleChange.ProposeTrueStepLength(totalTruePathLength);
+
+        // Inform G4Transportation that the momentum might have changed due
+        // to scattering. We do this unconditionally to avoid the situation
+        // where the last step is done without MSC and G4Transportation reset
+        // the flag, for example when running without field.
+        fMomentumChanged = true;
 
         return totalGeometryStepLength;
       }


### PR DESCRIPTION
This fixes a very rare bug when `G4Transportation` runs without field, `G4TransportationWithMsc` is allowed to make multiple internal steps, and the last internal step does *not* sample scattering (because the track is either ranging out, or the step is very small). In this case `G4Transportation` will reset `fMomentumChanged = false` because linear propagation does not change the momentum direction, when in fact earlier internal steps updated the direction due to scattering.

Instead always update the momentum direction because the above is rare. Numerical differences are observed in the simulation histories, but not statistically significant.