### PR TITLE
Fixed technical problems in Geant4 11.2.2

### DIFF
--- a/source/geometry/magneticfield/include/G4TMagFieldEquation.hh
+++ b/source/geometry/magneticfield/include/G4TMagFieldEquation.hh
@@ -36,7 +36,9 @@
 // Created: Josh Xie  (Google Summer of Code 2014 )
 // Adapted from G4Mag_UsualEqRhs
 // 
-// #include "G4ChargeState.hh"
+#ifndef G4TMAGFIELD_EQUATION_HH
+#define G4TMAGFIELD_EQUATION_HH
+
 #include "G4Mag_UsualEqRhs.hh"
 
 template 

--- a/source/geometry/magneticfield/include/G4TMagFieldEquation.hh
+++ b/source/geometry/magneticfield/include/G4TMagFieldEquation.hh
@@ -101,3 +101,4 @@ private:
   T_Field *itsField;
 };
 
+#endif

--- a/source/geometry/management/src/G4VSolid.cc
+++ b/source/geometry/management/src/G4VSolid.cc
@@ -203,7 +203,8 @@ G4double G4VSolid::GetCubicVolume()
 G4double G4VSolid::EstimateCubicVolume(G4int nStat, G4double epsilon) const
 {
   G4int iInside=0;
-  G4double px,py,pz,minX,maxX,minY,maxY,minZ,maxZ,volume,halfepsilon;
+  G4double px, py, pz, volume, halfepsilon;
+  G4double minX=0., maxX=0., minY=0., maxY=0., minZ=0., maxZ=0.;
   G4ThreeVector p;
   EInside in;
 

--- a/source/processes/hadronic/models/de_excitation/management/src/G4DeexPrecoParameters.cc
+++ b/source/processes/hadronic/models/de_excitation/management/src/G4DeexPrecoParameters.cc
@@ -67,7 +67,7 @@ void G4DeexPrecoParameters::Initialise()
   fPrecoHighEnergy = 30*CLHEP::MeV;
   fMinExcitation = 10*CLHEP::eV;
   fMaxLifeTime = 1*CLHEP::nanosecond;
-  fMinExPerNucleounForMF = 200*CLHEP::GeV;
+  fMinExPerNucleounForMF = 500*CLHEP::GeV;
 }
 
 void G4DeexPrecoParameters::SetLevelDensity(G4double val)

--- a/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMicroPartition.cc
+++ b/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMicroPartition.cc
@@ -191,14 +191,20 @@ G4double G4StatMFMicroPartition::CalcPartitionTemperature(G4double U,
   
   G4int maxit = 0;
   // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
-  while (Da*Db > 0.0 && maxit < 1000) 
-    {
-      ++maxit;
+  if (Da*Db < 0.0) {
+    G4bool yes = false;
+    for (G4int i=0; i < 1000; ++i) {
       Tb += 0.5*Tb; 	
       Db = (U + FreeInternalE0 - GetPartitionEnergy(Tb))/U;
+      if (Da*Db >= 0.0) {
+	yes = true;
+	break;
+      }
     }
+    if (!yes) { returmn -1.0; }
+  }
   
-  G4double eps = 1.0e-14*std::abs(Ta-Tb);
+  G4double eps = 1.0e-8*std::abs(Ta-Tb);
   
   for (G4int i = 0; i < 1000; i++) 
     {
@@ -217,10 +223,6 @@ G4double G4StatMFMicroPartition::CalcPartitionTemperature(G4double U,
           Da = Dmid;
         } 
     }
-  // if we arrive here the temperature could not be calculated
-  G4cout << "G4StatMFMicroPartition::CalcPartitionTemperature: I can't calculate the temperature"  
-         << G4endl;
-  // and set probability to 0 returning T < 0
   return -1.0;
   
 }

--- a/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMicroPartition.cc
+++ b/source/processes/hadronic/models/de_excitation/multifragmentation/src/G4StatMFMicroPartition.cc
@@ -201,7 +201,7 @@ G4double G4StatMFMicroPartition::CalcPartitionTemperature(G4double U,
 	break;
       }
     }
-    if (!yes) { returmn -1.0; }
+    if (!yes) { return -1.0; }
   }
   
   G4double eps = 1.0e-8*std::abs(Ta-Tb);


### PR DESCRIPTION
Proposed fixes:

1) reduce compilation warnings for gcc14 (https://github.com/cms-externals/geant4/issues/88).

2) protect numerical problem in multi-fragmentation model of nuclear de-excitation, which is responsible for very rare crash.

Because this PR only fix compilation warning and possible rare problem in hadronic physics a full regression is expected - no change in any any WF.