### PR TITLE
Fixed parallel voxelization flag

### DIFF
--- a/source/geometry/management/src/G4GeometryManager.cc
+++ b/source/geometry/management/src/G4GeometryManager.cc
@@ -71,7 +71,7 @@ G4VoxelisationHelper* G4GeometryManager::fParallelVoxeliser = nullptr;
  // Expected Future: data member (when only one instance)
 
 // Static *global* class data
-G4bool G4GeometryManager::fParallelVoxelOptimisationRequested = true;
+G4bool G4GeometryManager::fParallelVoxelOptimisationRequested = false;
   // Records User choice to use parallel voxel optimisation (or not)
 
 G4bool G4GeometryManager::fOptimiseInParallelConfigured = false;


### PR DESCRIPTION
CMS unit tests crash if the default value of the parallel initialization flag is used.  This PR fix the issue.