### PR TITLE
G4 11.2.2: Fix typo in member variable assignment

### DIFF
--- a/source/externals/g4tools/include/tools/wroot/columns.icc
+++ b/source/externals/g4tools/include/tools/wroot/columns.icc
@@ -399,7 +399,7 @@
   protected:
     std_vector_column_ref(const std_vector_column_ref& a_from)
     :icol(a_from)
-    ,m_branch(a_from.m_barnch)
+    ,m_branch(a_from.m_branch)
     ,m_ref(a_from.m_ref)
     ,m_leaf(0)
     ,m_leaf_count(0)


### PR DESCRIPTION
Building Geant4 with GCC 15 complained [a] . This has been fixed in newer version (11.3 and above) of Geant4 

[a]
/scratch/home/cmsbld/bootfc42/w/BUILD/fc42_riscv64_gcc15/external/geant4/11.2.2-653122ad8e0342c3b1ec206b9ea10013/external+geant4+11.2.2-653122ad8e0342c3b1ec206b9ea10013-1-build/geant4.11.2.2/source/externals/g4tools/include/tools/wroot/columns.icc: In copy constructor 'tools::wroot::ntuple::std_vector_column_ref<T>::std_vector_column_ref(const tools::wroot::ntuple::std_vector_column_ref<T>&)':
/scratch/home/cmsbld/bootfc42/w/BUILD/fc42_riscv64_gcc15/external/geant4/11.2.2-653122ad8e0342c3b1ec206b9ea10013/external+geant4+11.2.2-653122ad8e0342c3b1ec206b9ea10013-1-build/geant4.11.2.2/source/externals/g4tools/include/tools/wroot/columns.icc:402:22: error: 'const class tools::wroot::ntuple::std_vector_column_ref<T>' has no member named 'm_barnch'; did you mean 'm_branch'? [-Wtemplate-body]
  402 |     ,m_branch(a_from.m_barnch)
      |                      ^~~~~~~~
      |                      m_branch
