### PR TITLE
return back SetZero() method

### DIFF
--- a/source/processes/hadronic/util/include/G4ReactionProduct.hh
+++ b/source/processes/hadronic/util/include/G4ReactionProduct.hh
@@ -190,6 +190,8 @@ class G4ReactionProduct
     inline G4bool GetMayBeKilled() const
     { return MayBeKilled; }
 
+    void SetZero();
+  
     void Lorentz( const G4ReactionProduct &p1, const G4ReactionProduct &p2 );
     
     G4double Angle( const G4ReactionProduct &p ) const;

--- a/source/processes/hadronic/util/src/G4ReactionProduct.cc
+++ b/source/processes/hadronic/util/src/G4ReactionProduct.cc
@@ -135,6 +135,23 @@ void G4ReactionProduct::SetMomentum( const G4double z )
   momentum.setZ( z );
 }
 
+void G4ReactionProduct::SetZero()
+{
+  SetMomentum( 0.0, 0.0, 0.0 );
+  totalEnergy = 0.0;
+  kineticEnergy = 0.0;
+  mass = 0.0;
+  timeOfFlight = 0.0;
+  side = 0;
+  theCreatorModel = -1;
+  theParentResonanceDef = nullptr;
+  theParentResonanceID = 0;
+  NewlyAdded = false;
+  SetPositionInNucleus( 0.0, 0.0, 0.0 );
+  formationTime = 0.0;
+  hasInitialStateParton = false;
+}
+
 void G4ReactionProduct::Lorentz(
    const G4ReactionProduct &p1, const G4ReactionProduct &p2 )
 {


### PR DESCRIPTION
This method G4ReactionProduct::SetZero() is not used within Geant4 but is needed for CMSSW.